### PR TITLE
Fix at mentions

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,6 +5,6 @@
 
 Significant contributors to the Argo CD ApplicationSet Experiments Project:
 
-* @sven-lange-last
+* [sven-lange-last](https://github.com/sven-lange-last)
 
 This list is not necessarily complete. For a complete list, see the [GitHub repository's Contributors page](https://github.com/sven-lange-last/argocd-applicationset-experiments/graphs/contributors).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -62,7 +62,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement, i.e. @sven-lange-last.
+reported to the community leaders responsible for enforcement, i.e. [sven-lange-last](https://github.com/sven-lange-last).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
At (@) mentions do not work in GitHub markdown files. Replace with links to GitHub profiles.